### PR TITLE
Added method for parsing transformation rules from string

### DIFF
--- a/src/main/java/org/cqfn/astranaut/api/TreeProcessor.java
+++ b/src/main/java/org/cqfn/astranaut/api/TreeProcessor.java
@@ -70,17 +70,16 @@ public class TreeProcessor {
                     }
                 }
         );
-
-        return loadRulesFromString(code);
+        return this.loadRulesFromString(code);
     }
 
     /**
      * Loads rules of a tree transformation from the given string.
-     * @param rules DSL rules of a transformation
+     * @param code DSL rules of a transformation
      * @return The result, {@code true} if rules were successfully loaded
      */
-    public boolean loadRulesFromString(final String rules) {
-        final ProgramParser parser = new ProgramParser(rules);
+    public boolean loadRulesFromString(final String code) {
+        final ProgramParser parser = new ProgramParser(code);
         boolean success = true;
         try {
             final Program program = parser.parse();

--- a/src/main/java/org/cqfn/astranaut/api/TreeProcessor.java
+++ b/src/main/java/org/cqfn/astranaut/api/TreeProcessor.java
@@ -70,7 +70,17 @@ public class TreeProcessor {
                     }
                 }
         );
-        final ProgramParser parser = new ProgramParser(code);
+
+        return loadRulesFromString(code);
+    }
+
+    /**
+     * Loads rules of a tree transformation from the given string.
+     * @param rules DSL rules of a transformation
+     * @return The result, {@code true} if rules were successfully loaded
+     */
+    public boolean loadRulesFromString(final String rules) {
+        final ProgramParser parser = new ProgramParser(rules);
         boolean success = true;
         try {
             final Program program = parser.parse();

--- a/src/test/java/org/cqfn/astranaut/api/TreeProcessorTest.java
+++ b/src/test/java/org/cqfn/astranaut/api/TreeProcessorTest.java
@@ -70,6 +70,21 @@ public class TreeProcessorTest {
     }
 
     /**
+     * Test for a tree transformation with rules from a string
+     */
+    @Test
+    public void testTreeTransformationFromString() {
+        final Node tree = this.createSampleTree();
+        final TreeProcessor processor = new TreeProcessor();
+        processor.loadRulesFromString("Addition(IntegerLiteral<\"2\">, IntegerLiteral<\"3\">) -> IntegerLiteral<\"5\"> ;");
+        Node result = processor.transform(tree);
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(TreeProcessorTest.INT_LITERAL, result.getTypeName());
+        Assertions.assertEquals("5", result.getData());
+        Assertions.assertEquals(0, result.getChildCount());
+    }
+
+    /**
      * Test for exception while reading a DSL file.
      */
     @Test

--- a/src/test/java/org/cqfn/astranaut/api/TreeProcessorTest.java
+++ b/src/test/java/org/cqfn/astranaut/api/TreeProcessorTest.java
@@ -70,14 +70,16 @@ public class TreeProcessorTest {
     }
 
     /**
-     * Test for a tree transformation with rules from a string
+     * Test for a tree transformation with rules from a string.
      */
     @Test
     public void testTreeTransformationFromString() {
         final Node tree = this.createSampleTree();
         final TreeProcessor processor = new TreeProcessor();
-        processor.loadRulesFromString("Addition(IntegerLiteral<\"2\">, IntegerLiteral<\"3\">) -> IntegerLiteral<\"5\"> ;");
-        Node result = processor.transform(tree);
+        processor.loadRulesFromString(
+            "Addition(IntegerLiteral<\"2\">, IntegerLiteral<\"3\">) -> IntegerLiteral<\"5\"> ;"
+        );
+        final Node result = processor.transform(tree);
         Assertions.assertNotNull(result);
         Assertions.assertEquals(TreeProcessorTest.INT_LITERAL, result.getTypeName());
         Assertions.assertEquals("5", result.getData());


### PR DESCRIPTION
For single-line rules, it is much more convenient to pass them not through a file, so the user is not forced to access the file system.